### PR TITLE
change method names

### DIFF
--- a/lib/already_read/issue_patch.rb
+++ b/lib/already_read/issue_patch.rb
@@ -5,7 +5,7 @@ module AlreadyReadIssuePatch
     base.send(:include, InstanceMethods) # obj.method
 
     base.class_eval do
-      alias_method_chain :css_classes, :already_read
+      alias_method :css_classes, :already_read
     end
   end
 

--- a/lib/already_read/issue_query_patch.rb
+++ b/lib/already_read/issue_query_patch.rb
@@ -9,7 +9,7 @@ module AlreadyReadIssueQueryPatch
     base.send(:include, InstanceMethods) # obj.method
 
     base.class_eval do
-      alias_method_chain :available_filters, :already_read
+      alias_method :available_filters, :already_read
     end
   end
 


### PR DESCRIPTION
```
[redmine]()$ rake redmine:plugins:migrate RAILS_ENV=production
/var/lib/gems/2.7.0/gems/activerecord-5.2.8.1/lib/active_record/type.rb:27: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/var/lib/gems/2.7.0/gems/activerecord-5.2.8.1/lib/active_record/type/adapter_specific_registry.rb:9: warning: The called method `add_modifier' is defined here
/var/lib/gems/2.7.0/gems/activerecord-5.2.8.1/lib/active_record/associations.rb:1855: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/var/lib/gems/2.7.0/gems/activerecord-5.2.8.1/lib/active_record/associations.rb:1368: warning: The called method `has_many' is defined here
rake aborted!
NoMethodError: undefined method `alias_method_chain' for Issue (call 'Issue.connection' to establish a connection):Class
Did you mean?  alias_method
/var/lib/gems/2.7.0/gems/activerecord-5.2.8.1/lib/active_record/dynamic_matchers.rb:22:in `method_missing'
/var/lib/redmine/plugins/redmine_already_read/lib/already_read/issue_patch.rb:8:in `block in included'
/var/lib/redmine/plugins/redmine_already_read/lib/already_read/issue_patch.rb:7:in `class_eval'
/var/lib/redmine/plugins/redmine_already_read/lib/already_read/issue_patch.rb:7:in `included'
/var/lib/redmine/plugins/redmine_already_read/lib/already_read/issue_patch.rb:50:in `include'
/var/lib/redmine/plugins/redmine_already_read/lib/already_read/issue_patch.rb:50:in `<top (required)>'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:291:in `require'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:291:in `block in require'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:257:in `load_dependency'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:291:in `require'
/var/lib/redmine/plugins/redmine_already_read/init.rb:2:in `<top (required)>'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:291:in `require'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:291:in `block in require'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:257:in `load_dependency'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:291:in `require'
/var/lib/redmine/lib/redmine/plugin.rb:187:in `block in load'
/var/lib/redmine/lib/redmine/plugin.rb:178:in `each'
/var/lib/redmine/lib/redmine/plugin.rb:178:in `load'
/var/lib/redmine/config/initializers/30-redmine.rb:20:in `<top (required)>'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:285:in `load'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:285:in `block in load'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:257:in `load_dependency'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:285:in `load'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/engine.rb:663:in `block in load_config_initializer'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/notifications.rb:170:in `instrument'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/engine.rb:662:in `load_config_initializer'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/engine.rb:620:in `block (2 levels) in <class:Engine>'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/engine.rb:619:in `each'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/engine.rb:619:in `block in <class:Engine>'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/initializable.rb:32:in `instance_exec'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/initializable.rb:32:in `run'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/initializable.rb:61:in `block in run_initializers'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/initializable.rb:50:in `each'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/initializable.rb:50:in `tsort_each_child'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/initializable.rb:60:in `run_initializers'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/application.rb:361:in `initialize!'
/var/lib/redmine/config/environment.rb:16:in `<top (required)>'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/application.rb:337:in `require'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/application.rb:337:in `require_environment!'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/application.rb:520:in `block in run_tasks_blocks'
/var/lib/gems/2.7.0/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
Tasks: TOP => redmine:plugins:migrate => environment
(See full trace by running task with --trace)
[redmine]()$
[redmine]()$ sudo rake redmine:plugins:migrate RAILS_ENV=production
/var/lib/gems/2.7.0/gems/activerecord-5.2.8.1/lib/active_record/type.rb:27: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/var/lib/gems/2.7.0/gems/activerecord-5.2.8.1/lib/active_record/type/adapter_specific_registry.rb:9: warning: The called method `add_modifier' is defined here
/var/lib/gems/2.7.0/gems/activerecord-5.2.8.1/lib/active_record/associations.rb:1855: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/var/lib/gems/2.7.0/gems/activerecord-5.2.8.1/lib/active_record/associations.rb:1368: warning: The called method `has_many' is defined here
rake aborted!
NoMethodError: undefined method `alias_method_chain' for Issue (call 'Issue.connection' to establish a connection):Class
Did you mean?  alias_method
/var/lib/gems/2.7.0/gems/activerecord-5.2.8.1/lib/active_record/dynamic_matchers.rb:22:in `method_missing'
/var/lib/redmine/plugins/redmine_already_read/lib/already_read/issue_patch.rb:8:in `block in included'
/var/lib/redmine/plugins/redmine_already_read/lib/already_read/issue_patch.rb:7:in `class_eval'
/var/lib/redmine/plugins/redmine_already_read/lib/already_read/issue_patch.rb:7:in `included'
/var/lib/redmine/plugins/redmine_already_read/lib/already_read/issue_patch.rb:50:in `include'
/var/lib/redmine/plugins/redmine_already_read/lib/already_read/issue_patch.rb:50:in `<top (required)>'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:291:in `require'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:291:in `block in require'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:257:in `load_dependency'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:291:in `require'
/var/lib/redmine/plugins/redmine_already_read/init.rb:2:in `<top (required)>'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:291:in `require'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:291:in `block in require'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:257:in `load_dependency'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:291:in `require'
/var/lib/redmine/lib/redmine/plugin.rb:187:in `block in load'
/var/lib/redmine/lib/redmine/plugin.rb:178:in `each'
/var/lib/redmine/lib/redmine/plugin.rb:178:in `load'
/var/lib/redmine/config/initializers/30-redmine.rb:20:in `<top (required)>'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:285:in `load'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:285:in `block in load'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:257:in `load_dependency'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:285:in `load'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/engine.rb:663:in `block in load_config_initializer'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/notifications.rb:170:in `instrument'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/engine.rb:662:in `load_config_initializer'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/engine.rb:620:in `block (2 levels) in <class:Engine>'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/engine.rb:619:in `each'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/engine.rb:619:in `block in <class:Engine>'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/initializable.rb:32:in `instance_exec'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/initializable.rb:32:in `run'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/initializable.rb:61:in `block in run_initializers'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/initializable.rb:50:in `each'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/initializable.rb:50:in `tsort_each_child'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/initializable.rb:60:in `run_initializers'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/application.rb:361:in `initialize!'
/var/lib/redmine/config/environment.rb:16:in `<top (required)>'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/application.rb:337:in `require'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/application.rb:337:in `require_environment!'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/application.rb:520:in `block in run_tasks_blocks'
/var/lib/gems/2.7.0/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
Tasks: TOP => redmine:plugins:migrate => environment
(See full trace by running task with --trace)
[redmine]()$ sudo rake redmine:plugins:migrate RAILS_ENV=production --trace
** Invoke redmine:plugins:migrate (first_time)
** Invoke environment (first_time)
** Execute environment
/var/lib/gems/2.7.0/gems/activerecord-5.2.8.1/lib/active_record/type.rb:27: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/var/lib/gems/2.7.0/gems/activerecord-5.2.8.1/lib/active_record/type/adapter_specific_registry.rb:9: warning: The called method `add_modifier' is defined here
/var/lib/gems/2.7.0/gems/activerecord-5.2.8.1/lib/active_record/associations.rb:1855: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/var/lib/gems/2.7.0/gems/activerecord-5.2.8.1/lib/active_record/associations.rb:1368: warning: The called method `has_many' is defined here
rake aborted!
NoMethodError: undefined method `alias_method_chain' for Issue (call 'Issue.connection' to establish a connection):Class
Did you mean?  alias_method
/var/lib/gems/2.7.0/gems/activerecord-5.2.8.1/lib/active_record/dynamic_matchers.rb:22:in `method_missing'
/var/lib/redmine/plugins/redmine_already_read/lib/already_read/issue_patch.rb:8:in `block in included'
/var/lib/redmine/plugins/redmine_already_read/lib/already_read/issue_patch.rb:7:in `class_eval'
/var/lib/redmine/plugins/redmine_already_read/lib/already_read/issue_patch.rb:7:in `included'
/var/lib/redmine/plugins/redmine_already_read/lib/already_read/issue_patch.rb:50:in `include'
/var/lib/redmine/plugins/redmine_already_read/lib/already_read/issue_patch.rb:50:in `<top (required)>'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:291:in `require'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:291:in `block in require'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:257:in `load_dependency'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:291:in `require'
/var/lib/redmine/plugins/redmine_already_read/init.rb:2:in `<top (required)>'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:291:in `require'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:291:in `block in require'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:257:in `load_dependency'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:291:in `require'
/var/lib/redmine/lib/redmine/plugin.rb:187:in `block in load'
/var/lib/redmine/lib/redmine/plugin.rb:178:in `each'
/var/lib/redmine/lib/redmine/plugin.rb:178:in `load'
/var/lib/redmine/config/initializers/30-redmine.rb:20:in `<top (required)>'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:285:in `load'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:285:in `block in load'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:257:in `load_dependency'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:285:in `load'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/engine.rb:663:in `block in load_config_initializer'
/var/lib/gems/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/notifications.rb:170:in `instrument'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/engine.rb:662:in `load_config_initializer'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/engine.rb:620:in `block (2 levels) in <class:Engine>'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/engine.rb:619:in `each'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/engine.rb:619:in `block in <class:Engine>'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/initializable.rb:32:in `instance_exec'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/initializable.rb:32:in `run'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/initializable.rb:61:in `block in run_initializers'
/usr/lib/ruby/2.7.0/tsort.rb:228:in `block in tsort_each'
/usr/lib/ruby/2.7.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
/usr/lib/ruby/2.7.0/tsort.rb:422:in `block (2 levels) in each_strongly_connected_component_from'
/usr/lib/ruby/2.7.0/tsort.rb:431:in `each_strongly_connected_component_from'
/usr/lib/ruby/2.7.0/tsort.rb:421:in `block in each_strongly_connected_component_from'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/initializable.rb:50:in `each'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/initializable.rb:50:in `tsort_each_child'
/usr/lib/ruby/2.7.0/tsort.rb:415:in `call'
/usr/lib/ruby/2.7.0/tsort.rb:415:in `each_strongly_connected_component_from'
/usr/lib/ruby/2.7.0/tsort.rb:349:in `block in each_strongly_connected_component'
/usr/lib/ruby/2.7.0/tsort.rb:347:in `each'
/usr/lib/ruby/2.7.0/tsort.rb:347:in `call'
/usr/lib/ruby/2.7.0/tsort.rb:347:in `each_strongly_connected_component'
/usr/lib/ruby/2.7.0/tsort.rb:226:in `tsort_each'
/usr/lib/ruby/2.7.0/tsort.rb:205:in `tsort_each'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/initializable.rb:60:in `run_initializers'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/application.rb:361:in `initialize!'
/var/lib/redmine/config/environment.rb:16:in `<top (required)>'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/application.rb:337:in `require'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/application.rb:337:in `require_environment!'
/var/lib/gems/2.7.0/gems/railties-5.2.8.1/lib/rails/application.rb:520:in `block in run_tasks_blocks'
/var/lib/gems/2.7.0/gems/rake-13.0.6/lib/rake/task.rb:281:in `block in execute'
/var/lib/gems/2.7.0/gems/rake-13.0.6/lib/rake/task.rb:281:in `each'
/var/lib/gems/2.7.0/gems/rake-13.0.6/lib/rake/task.rb:281:in `execute'
/var/lib/gems/2.7.0/gems/rake-13.0.6/lib/rake/task.rb:219:in `block in invoke_with_call_chain'
/var/lib/gems/2.7.0/gems/rake-13.0.6/lib/rake/task.rb:199:in `synchronize'
/var/lib/gems/2.7.0/gems/rake-13.0.6/lib/rake/task.rb:199:in `invoke_with_call_chain'
/var/lib/gems/2.7.0/gems/rake-13.0.6/lib/rake/task.rb:243:in `block in invoke_prerequisites'
/var/lib/gems/2.7.0/gems/rake-13.0.6/lib/rake/task.rb:241:in `each'
/var/lib/gems/2.7.0/gems/rake-13.0.6/lib/rake/task.rb:241:in `invoke_prerequisites'
/var/lib/gems/2.7.0/gems/rake-13.0.6/lib/rake/task.rb:218:in `block in invoke_with_call_chain'
/var/lib/gems/2.7.0/gems/rake-13.0.6/lib/rake/task.rb:199:in `synchronize'
/var/lib/gems/2.7.0/gems/rake-13.0.6/lib/rake/task.rb:199:in `invoke_with_call_chain'
/var/lib/gems/2.7.0/gems/rake-13.0.6/lib/rake/task.rb:188:in `invoke'
/var/lib/gems/2.7.0/gems/rake-13.0.6/lib/rake/application.rb:160:in `invoke_task'
/var/lib/gems/2.7.0/gems/rake-13.0.6/lib/rake/application.rb:116:in `block (2 levels) in top_level'
/var/lib/gems/2.7.0/gems/rake-13.0.6/lib/rake/application.rb:116:in `each'
/var/lib/gems/2.7.0/gems/rake-13.0.6/lib/rake/application.rb:116:in `block in top_level'
/var/lib/gems/2.7.0/gems/rake-13.0.6/lib/rake/application.rb:125:in `run_with_threads'
/var/lib/gems/2.7.0/gems/rake-13.0.6/lib/rake/application.rb:110:in `top_level'
/var/lib/gems/2.7.0/gems/rake-13.0.6/lib/rake/application.rb:83:in `block in run'
/var/lib/gems/2.7.0/gems/rake-13.0.6/lib/rake/application.rb:186:in `standard_exception_handling'
/var/lib/gems/2.7.0/gems/rake-13.0.6/lib/rake/application.rb:80:in `run'
/var/lib/gems/2.7.0/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
/usr/local/bin/rake:23:in `load'
/usr/local/bin/rake:23:in `<main>'
Tasks: TOP => redmine:plugins:migrate => environment
```